### PR TITLE
Code revisions from second review

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -386,6 +386,19 @@ If your NEXUS-formatted output is to be used by a phylogenetic software that ign
 Note that for the ``nexus``, ``hennig86``, ``phylip``, and ``fasta`` output formats, only up to 32 states (represented by the symbols 0-9 and a-v) are supported at this time.
 This is a requirement for Hennig86 format, and some phylogenetic programs that use these formats (such as IQTREE and RAxML) do not support symbols outside of the basic 36 alphanumeric characters or a 32-character alphabet at this time.
 
+Collations can also be converted to tabular formats.
+Within Python, the ``collation`` class's ``to_numpy`` method can be invoked to convert a collation to a NumPy matrix with rows for variant readings, columns for witnesses, and frequency values in the cells.
+Where a witness has missing data at a variation, its frequencies for different readings at this unit can be split evenly over 1 using the ``split_missing`` argument; otherwise, the witness will have frequencies of 0 for all readings at that unit.
+The same class's ``to_distance_matrix`` method produces a NumPy matrix with rows and columns for witnesses, where each cell contains the number of units where the row witness and column witness both have unambiguous readings and these readings disagree.
+The cells can instead be populated with the proportion of disagreements to units where the row and column witnesses have readings with the ``proportion`` argument.
+The same class's ``to_long_table`` method produces a NumPy matrix with columns for witness ID, variation unit ID, reading index, and reading text and rows for all combinations of these values found in the collation.
+The ``to_dataframe`` method invokes either ``to_numpy`` or ``to_long_table`` (depending on whether its ``long_table`` argument is true) and returns a Pandas ``DataFrame`` augmented with row and column labels (or, in the case of a long table, just column labels). 
+
+From the command line, the standard reading-witness matrix or long table can be written to a specified CSV, TSV, or Excel (.xlsx) file.
+If you specify the output filename with its extension, ``teiphy`` will infer which format to use. 
+If you are writing a reading-witness matrix to output, you can set the method's ``split_missing`` argument using the ``--split-missing`` command-line flag.
+If you want to write a long table to output instead of a reading-witness matrix, then you can do so by including the ``--long-table`` command-line flag.
+
 Other Options
 -------------
 

--- a/teiphy/main.py
+++ b/teiphy/main.py
@@ -1,5 +1,5 @@
 from typing import List  # for list-like inputs
-from importlib.metadata import version # for checking package version
+from importlib.metadata import version  # for checking package version
 from pathlib import Path  # for validating file address inputs
 from lxml import etree as et  # for parsing XML input
 import typer
@@ -10,11 +10,13 @@ from .collation import Collation
 
 app = typer.Typer(rich_markup_mode="rich")
 
+
 def version_callback(value: bool):
     if value:
         teiphy_version = version("teiphy")
         typer.echo(teiphy_version)
         raise typer.Exit()
+
 
 @app.command()
 def to_file(
@@ -56,6 +58,14 @@ def to_file(
     mrbayes: bool = typer.Option(
         False,
         help="Add a MrBayes block containing model settings and age calibrations for witnesses to NEXUS output; this option is intended for inputs to MrBayes.",
+    ),
+    long_table: bool = typer.Option(
+        False,
+        help="Generate a long table with columns for taxa, characters, reading indices, and reading values instead of a matrix. Not applicable for NEXUS, HENNIG86, PHYLIP, FASTA, or STEMMA format. Note that if this option is set, ambiguous readings will be treated as missing data, and the --split-missing option will be ignored.",
+    ),
+    split_missing: bool = typer.Option(
+        False,
+        help="Treat missing characters/variation units as having a contribution of 1 split over all states/readings; if False, then missing data is ignored (i.e., all states are 0). Not applicable for NEXUS, HENNIG86, PHYLIP, FASTA, or STEMMA format.",
     ),
     verbose: bool = typer.Option(False, help="Enable verbose logging (mostly for debugging purposes)."),
     version: bool = typer.Option(
@@ -106,4 +116,6 @@ def to_file(
         ambiguous_as_missing=ambiguous_as_missing,
         calibrate_dates=calibrate_dates,
         mrbayes=mrbayes,
+        long_table=long_table,
+        split_missing=split_missing,
     )

--- a/tests/test_collation.py
+++ b/tests/test_collation.py
@@ -297,6 +297,16 @@ class CollationOutputTestCase(unittest.TestCase):
             abs(matrix[0, 1] - 13 / 38) < 1e-4
         )  # entry for UBS and P46 should be close to 13/38 (of 40 substantive variation units, P46 is lacunose at one and ambiguous at another)
 
+    def test_to_long_table(self):
+        long_table, column_labels = self.collation.to_long_table()
+        self.assertEqual(
+            column_labels, ["taxon", "character", "state", "value"]
+        )  # lacuna in the first witness should result in its column summing to less than the total number of substantive variation units
+        self.assertEqual(long_table[0, 0], "UBS")  # first row should contain UBS,B10K1V1U24-26,0,εν εφεσω
+        self.assertEqual(long_table[0, 1], "B10K1V1U24-26")  # first row should contain UBS,B10K1V1U24-26,0,εν εφεσω
+        self.assertEqual(long_table[0, 2], "0")  # first row should contain UBS,B10K1V1U24-26,0,εν εφεσω
+        self.assertEqual(long_table[0, 3], "εν εφεσω")  # first row should contain UBS,B10K1V1U24-26,0,εν εφεσω
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -249,6 +249,16 @@ def test_to_csv():
         assert text.startswith(",UBS,P46,01,02,03,04,06")
 
 
+def test_to_csv_long_table():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output = Path(tmp_dir) / "test.csv"
+        result = runner.invoke(app, ["--long-table", str(input_example), str(output)])
+        assert result.exit_code == 0
+        assert output.exists()
+        text = output.read_text(encoding="utf-8")
+        assert text.startswith("taxon,character,state,value")
+
+
 def test_to_tsv():
     with tempfile.TemporaryDirectory() as tmp_dir:
         output = Path(tmp_dir) / "test.tsv"
@@ -259,10 +269,28 @@ def test_to_tsv():
         assert text.startswith("\tUBS\tP46\t01\t02\t03\t04\t06")
 
 
+def test_to_tsv_long_table():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output = Path(tmp_dir) / "test.tsv"
+        result = runner.invoke(app, ["--long-table", str(input_example), str(output)])
+        assert result.exit_code == 0
+        assert output.exists()
+        text = output.read_text(encoding="utf-8")
+        assert text.startswith("taxon\tcharacter\tstate\tvalue")
+
+
 def test_to_excel():
     with tempfile.TemporaryDirectory() as tmp_dir:
         output = Path(tmp_dir) / "test.xlsx"
         result = runner.invoke(app, [str(input_example), str(output)])
+        assert result.exit_code == 0
+        assert output.exists()
+
+
+def test_to_excel_long_table():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output = Path(tmp_dir) / "test.xlsx"
+        result = runner.invoke(app, ["--long-table", str(input_example), str(output)])
         assert result.exit_code == 0
         assert output.exists()
 


### PR DESCRIPTION
Swapped `--states-present` option with `--frequency` option (and made StatesPresent the default encoding for NEXUS output) and added support for `--long-table` option to generate a long-form collation table with rows consisting of (taxon, character, state, value) tuples.